### PR TITLE
Remove trailing whitespace from cmd output

### DIFF
--- a/evil-winrm.rb
+++ b/evil-winrm.rb
@@ -530,7 +530,9 @@ class EvilWinRM
                     end
 
                     output = shell.run(command) do |stdout, stderr|
-                        STDOUT.print(stdout)
+                        stdout&.each_line do |line|
+                            STDOUT.puts(line.rstrip!)
+                        end
                         STDERR.print(stderr)
                     end
                 end


### PR DESCRIPTION
<!--- Please, before sending a pull request read the Git Workflow Policy on Contributing section of the project -->
<!--- Pull requests to master are not allowed -->
<!--- Write in English only -->
<!--- If the pull request is not matching the policy, it will be closed -->

#### Describe the purpose of the pull request

<!--- Insert answer here -->
Trailing whitespace from the output of certain shell commands (most notably `Get-ChildItem`) keeps leaving annoying blank lines between lines of legit output if the terminal isn't wide enough and the whitespace wraps around.
By stripping the whitespace at the end of each line, the output of such commands is much more readable, and should not break any existing formatting.