### PR TITLE
Add progress bar on uploader

### DIFF
--- a/evil-winrm.rb
+++ b/evil-winrm.rb
@@ -317,6 +317,16 @@ class EvilWinRM
         exit(exit_code)
     end
 
+    def progress_bar(bytes_done, total_bytes)
+            progress = ((bytes_done.to_f / total_bytes.to_f) * 100).round
+            progress_bar = (progress / 10).round
+            progress_string = "▓" * (progress_bar-1).clamp(0,9)
+            progress_string = progress_string + "▒" + ("░" * (10-progress_bar))
+            message = "Progress: #{progress}% : |#{progress_string}|          \r"
+            print message
+            $stdout.flush
+    end
+
     # Main function
     def main
         self.arguments()
@@ -418,6 +428,7 @@ class EvilWinRM
                             begin
                                 self.print_message("Uploading #{upload_command[1]} to #{upload_command[2]}", TYPE_INFO)
                                 file_manager.upload(upload_command[1], upload_command[2]) do |bytes_copied, total_bytes|
+                                    progress_bar(bytes_copied, total_bytes)
                                     if bytes_copied == total_bytes then
                                         self.print_message("#{bytes_copied} bytes of #{total_bytes} bytes copied", TYPE_DATA)
                                         self.print_message("Upload successful!", TYPE_INFO)


### PR DESCRIPTION
#### Describe the purpose of the pull request

This adds a percentage and graphical representation of the progress of the upload. The progress bar updates in place, and is overwritten upon completion. I did attempt to add this to the downloader as well, but the downloader from winrm-fs doesn't seem to give variables to show progress ([uploader](https://www.rubydoc.info/gems/winrm-fs/0.2.3/WinRM%2FFS%2FFileManager:upload) vs [downloader](https://www.rubydoc.info/gems/winrm-fs/0.2.3/WinRM%2FFS%2FFileManager:download) docs). I thought this would be a useful addition, as while uploading files (particularly if done over a proxy) it can be helpful to know the connection hasn't hung.

**Note**: I use 3 characters to represent the progress bar (empty, partial fill and filled). These render differently on browsers vs consoles, and should probably be changed to some other equal-width characters that render more predictably.