### PR TITLE
Add progress bar to downloader

### DIFF
--- a/evil-winrm.rb
+++ b/evil-winrm.rb
@@ -469,7 +469,7 @@ class EvilWinRM
                                 file_manager.upload(upload_command[1], upload_command[2]) do |bytes_copied, total_bytes|
                                     progress_bar(bytes_copied, total_bytes)
                                     if bytes_copied == total_bytes then
-                                        puts ()
+                                        puts()
                                         self.print_message("#{bytes_copied} bytes of #{total_bytes} bytes copied", TYPE_DATA)
                                         self.print_message("Upload successful!", TYPE_INFO)
                                     end
@@ -496,7 +496,7 @@ class EvilWinRM
                                 file_manager.download(download_command[1], download_command[2], size: size) do | index, size |
                                     progress_bar(index, size)
                                 end
-                                puts ()
+                                puts()
                                 self.print_message("Download successful!", TYPE_INFO)
                             rescue
                                 self.print_message("Download failed. Check filenames or paths", TYPE_ERROR)

--- a/evil-winrm.rb
+++ b/evil-winrm.rb
@@ -469,7 +469,7 @@ class EvilWinRM
                                 file_manager.upload(upload_command[1], upload_command[2]) do |bytes_copied, total_bytes|
                                     progress_bar(bytes_copied, total_bytes)
                                     if bytes_copied == total_bytes then
-                                        print ""
+                                        puts ()
                                         self.print_message("#{bytes_copied} bytes of #{total_bytes} bytes copied", TYPE_DATA)
                                         self.print_message("Upload successful!", TYPE_INFO)
                                     end
@@ -496,7 +496,7 @@ class EvilWinRM
                                 file_manager.download(download_command[1], download_command[2], size: size) do | index, size |
                                     progress_bar(index, size)
                                 end
-                                print ""
+                                puts ()
                                 self.print_message("Download successful!", TYPE_INFO)
                             rescue
                                 self.print_message("Download failed. Check filenames or paths", TYPE_ERROR)
@@ -630,3 +630,4 @@ end
 # Execution
 e = EvilWinRM.new
 e.main
+

--- a/evil-winrm.rb
+++ b/evil-winrm.rb
@@ -469,7 +469,7 @@ class EvilWinRM
                                 file_manager.upload(upload_command[1], upload_command[2]) do |bytes_copied, total_bytes|
                                     progress_bar(bytes_copied, total_bytes)
                                     if bytes_copied == total_bytes then
-                                        puts()
+                                        puts("                                                             ")
                                         self.print_message("#{bytes_copied} bytes of #{total_bytes} bytes copied", TYPE_DATA)
                                         self.print_message("Upload successful!", TYPE_INFO)
                                     end
@@ -496,7 +496,7 @@ class EvilWinRM
                                 file_manager.download(download_command[1], download_command[2], size: size) do | index, size |
                                     progress_bar(index, size)
                                 end
-                                puts()
+                                puts("                                                             ")
                                 self.print_message("Download successful!", TYPE_INFO)
                             rescue
                                 self.print_message("Download failed. Check filenames or paths", TYPE_ERROR)

--- a/evil-winrm.rb
+++ b/evil-winrm.rb
@@ -47,6 +47,38 @@ $user = ""
 $password = ""
 $url = "wsman"
 
+# Redefine download method from winrm-fs
+module WinRM
+    module FS
+        class FileManager
+            def download(remote_path, local_path, chunk_size = 1024 * 1024, first = true, size: -1)
+                @logger.debug("downloading: #{remote_path} -> #{local_path} #{chunk_size}")
+                index = 0
+                output = _output_from_file(remote_path, chunk_size, index)
+                return download_dir(remote_path, local_path, chunk_size, first) if output.exitcode == 2
+
+                return false if output.exitcode >= 1
+
+                File.open(local_path, 'wb') do |fd|
+                    out = _write_file(fd, output)
+                    index += out.length
+                    until out.empty?
+                        if size != -1
+                            yield index, size
+                        end
+                        output = _output_from_file(remote_path, chunk_size, index)
+                        return false if output.exitcode >= 1
+
+                        out = _write_file(fd, output)
+                        index += out.length
+                    end
+                end
+            end
+
+            true
+        end
+    end
+end
 
 # Class creation
 class EvilWinRM
@@ -328,6 +360,12 @@ class EvilWinRM
             $stdout.flush
     end
 
+    # Get filesize
+    def filesize(shell, path)
+        size = shell.run("(get-item #{path}).length").output.strip.to_i
+        return size
+    end
+
     # Main function
     def main
         self.arguments()
@@ -431,6 +469,7 @@ class EvilWinRM
                                 file_manager.upload(upload_command[1], upload_command[2]) do |bytes_copied, total_bytes|
                                     progress_bar(bytes_copied, total_bytes)
                                     if bytes_copied == total_bytes then
+                                        print ""
                                         self.print_message("#{bytes_copied} bytes of #{total_bytes} bytes copied", TYPE_DATA)
                                         self.print_message("Upload successful!", TYPE_INFO)
                                     end
@@ -453,7 +492,11 @@ class EvilWinRM
 
                             begin
                                 self.print_message("Downloading #{download_command[1]} to #{download_command[2]}", TYPE_INFO)
-                                file_manager.download(download_command[1], download_command[2])
+                                size = self.filesize(shell, download_command[1])
+                                file_manager.download(download_command[1], download_command[2], size: size) do | index, size |
+                                    progress_bar(index, size)
+                                end
+                                print ""
                                 self.print_message("Download successful!", TYPE_INFO)
                             rescue
                                 self.print_message("Download failed. Check filenames or paths", TYPE_ERROR)


### PR DESCRIPTION
#### Describe the purpose of the pull request

This adds the progress bar to the file downloader as well as the uploader. To do this, I had to redefine winrm-fs's file downloader to yield the bytes downloaded as well as the current size. This also meant adding a function to get the target filesize.

Slightly changed the progress bar to print a newline after completion, this prevents issues where the progress bar was getting partially covered due to the carriage return.
