### PR TITLE
Fixed downloading path with spaces

### DIFF
--- a/evil-winrm.rb
+++ b/evil-winrm.rb
@@ -362,7 +362,7 @@ class EvilWinRM
 
     # Get filesize
     def filesize(shell, path)
-        size = shell.run("(get-item #{path}).length").output.strip.to_i
+        size = shell.run("(get-item '#{path}').length").output.strip.to_i
         return size
     end
 


### PR DESCRIPTION
#### Fixes downloading path with spaces
By adding single quotes around the path while retrieving the length paths with spaces do not cause an error. Fixes the issue from #23