### PR TITLE
Remove "bundled with"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -40,6 +40,3 @@ DEPENDENCIES
   stringio
   winrm
   winrm-fs
-
-BUNDLED WITH
-   2.0.2


### PR DESCRIPTION
Just remove "bundled with" to make sure that you local bundler version doesn't matter and not conflict during install dependencies with bundler .