### PR TITLE
Add service option allowing different SPN prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,18 +36,19 @@ purposes by system administrators as well but the most of its features are focus
 
 ## Help
 ```
-Usage: evil-winrm -i IP -u USER [-s SCRIPTS_PATH] [-e EXES_PATH] [-P PORT] [-p PASS] [-H HASH] [-U URL] [-S] [-c PUBLIC_KEY_PATH ] [-k PRIVATE_KEY_PATH ] [-r REALM]
+Usage: evil-winrm -i IP -u USER [-s SCRIPTS_PATH] [-e EXES_PATH] [-P PORT] [-p PASS] [-H HASH] [-U URL] [-S] [-c PUBLIC_KEY_PATH ] [-k PRIVATE_KEY_PATH ] [-r REALM] [--spn SPN_PREFIX]
     -S, --ssl                        Enable ssl
     -c, --pub-key PUBLIC_KEY_PATH    Local path to public key certificate
     -k, --priv-key PRIVATE_KEY_PATH  Local path to private key certificate
     -r, --realm DOMAIN               Kerberos auth, it has to be set also in /etc/krb5.conf file using this format -> CONTOSO.COM = { kdc = fooserver.contoso.com }
     -s, --scripts PS_SCRIPTS_PATH    Powershell scripts local path
+        --spn SPN_PREFIX             SPN prefix for Kerberos auth (default HTTP)
     -e, --executables EXES_PATH      C# executables local path
-    -i, --ip IP                      Remote host IP or hostname (required)
-    -U, --url URL                    Remote url endpoint (default wsman)
+    -i, --ip IP                      Remote host IP or hostname. FQDN for Kerberos auth (required)
+    -U, --url URL                    Remote url endpoint (default /wsman)
     -u, --user USER                  Username (required if not using kerberos)
     -p, --password PASS              Password
-    -H, --hash NTHash                NTHash 
+    -H, --hash HASH                  NTHash
     -P, --port PORT                  Remote host port (default 5985)
     -V, --version                    Show version
     -n, --no-colors                  Disable colors

--- a/evil-winrm.rb
+++ b/evil-winrm.rb
@@ -88,7 +88,7 @@ class EvilWinRM
     def arguments()
         options = { port:$port, url:$url, service:$service }
         optparse = OptionParser.new do |opts|
-            opts.banner = "Usage: evil-winrm -i IP -u USER [-s SCRIPTS_PATH] [-e EXES_PATH] [-P PORT] [-p PASS] [-H HASH] [-U URL] [-S] [-c PUBLIC_KEY_PATH ] [-k PRIVATE_KEY_PATH ] [-r REALM]"
+            opts.banner = "Usage: evil-winrm -i IP -u USER [-s SCRIPTS_PATH] [-e EXES_PATH] [-P PORT] [-p PASS] [-H HASH] [-U URL] [-S] [-c PUBLIC_KEY_PATH ] [-k PRIVATE_KEY_PATH ] [-r REALM] [--spn SPN_PREFIX]"
             opts.on("-S", "--ssl", "Enable ssl") do |val|
                 $ssl = true
                 options[:port] = "5986"
@@ -97,11 +97,11 @@ class EvilWinRM
             opts.on("-k", "--priv-key PRIVATE_KEY_PATH", "Local path to private key certificate") { |val| options[:priv_key] = val }
             opts.on("-r", "--realm DOMAIN", "Kerberos auth, it has to be set also in /etc/krb5.conf file using this format -> CONTOSO.COM = { kdc = fooserver.contoso.com }") { |val| options[:realm] = val.upcase }
             opts.on("-s", "--scripts PS_SCRIPTS_PATH", "Powershell scripts local path") { |val| options[:scripts] = val }
-            opts.on("-S", "--service SPN_PREFIX", "Prefix of the SPN (default HTTP)") { |val| options[:service] = val }
+            opts.on("--spn SPN_PREFIX", "SPN prefix for Kerberos auth (default HTTP)") { |val| options[:service] = val }
             opts.on("-e", "--executables EXES_PATH", "C# executables local path") { |val| options[:executables] = val }
             opts.on("-i", "--ip IP", "Remote host IP or hostname. FQDN for Kerberos auth (required)") { |val| options[:ip] = val }
             opts.on("-U", "--url URL", "Remote url endpoint (default /wsman)") { |val| options[:url] = val }
-            opts.on("-u", "--user USER", "Username (required)") { |val| options[:user] = val }
+            opts.on("-u", "--user USER", "Username (required if not using kerberos)") { |val| options[:user] = val }
             opts.on("-p", "--password PASS", "Password") { |val| options[:password] = val }
             opts.on("-H", "--hash HASH", "NTHash") do |val|
                 if !options[:password].nil? and !val.nil?

--- a/evil-winrm.rb
+++ b/evil-winrm.rb
@@ -46,6 +46,7 @@ $port = "5985"
 $user = ""
 $password = ""
 $url = "wsman"
+$service = "HTTP"
 
 # Redefine download method from winrm-fs
 module WinRM
@@ -85,7 +86,7 @@ class EvilWinRM
 
     # Arguments
     def arguments()
-        options = { port:$port, url:$url }
+        options = { port:$port, url:$url, service:$service }
         optparse = OptionParser.new do |opts|
             opts.banner = "Usage: evil-winrm -i IP -u USER [-s SCRIPTS_PATH] [-e EXES_PATH] [-P PORT] [-p PASS] [-H HASH] [-U URL] [-S] [-c PUBLIC_KEY_PATH ] [-k PRIVATE_KEY_PATH ] [-r REALM]"
             opts.on("-S", "--ssl", "Enable ssl") do |val|
@@ -96,6 +97,7 @@ class EvilWinRM
             opts.on("-k", "--priv-key PRIVATE_KEY_PATH", "Local path to private key certificate") { |val| options[:priv_key] = val }
             opts.on("-r", "--realm DOMAIN", "Kerberos auth, it has to be set also in /etc/krb5.conf file using this format -> CONTOSO.COM = { kdc = fooserver.contoso.com }") { |val| options[:realm] = val.upcase }
             opts.on("-s", "--scripts PS_SCRIPTS_PATH", "Powershell scripts local path") { |val| options[:scripts] = val }
+            opts.on("-S", "--service SPN_PREFIX", "Prefix of the SPN (default HTTP)") { |val| options[:service] = val }
             opts.on("-e", "--executables EXES_PATH", "C# executables local path") { |val| options[:executables] = val }
             opts.on("-i", "--ip IP", "Remote host IP or hostname. FQDN for Kerberos auth (required)") { |val| options[:ip] = val }
             opts.on("-U", "--url URL", "Remote url endpoint (default /wsman)") { |val| options[:url] = val }
@@ -163,6 +165,7 @@ class EvilWinRM
         $pub_key = options[:pub_key]
         $priv_key = options[:priv_key]
         $realm = options[:realm]
+        $service = options[:service]
     end
 
     # Print script header
@@ -200,7 +203,8 @@ class EvilWinRM
                 user: "",
                 password: "",
                 transport: :kerberos,
-                realm: $realm
+                realm: $realm,
+                service: $service
             )
         else
             $conn = WinRM::Connection.new(


### PR DESCRIPTION
On Kerberos connections, *evil-winrm* does currently not specify a service name explicitly. This will lead to the default SPN prefix 'HTTP', which is fine in most cases. However, in certain scenarios it is useful to allow different SPN names (e.g. like WSMAN).

This pull request introduces a new command line argument (-S, --service), which can be used to specify the SPN prefix explicitly. If not specified, the default prefix (HTTP) is used.

In the following example, a silver ticket was generated with a SPN prefix ``http`` instead of the uppercase format ``HTTP``. As shown below, this is not recognized by *evil-winrm*:

```console
[pentester@kali ~]$ klist
Ticket cache: FILE:/tmp/krb5cc_1000
Default principal: administrator@EXAMPLE.LAB

Valid starting     Expires            Service principal
06/19/20 07:03:20  06/17/30 07:03:20  http/dev.example.lab@EXAMPLE.LAB
	renew until 06/17/30 07:03:20
[pentester@kali ~]$ evil-winrm.rb -i dev.example.lab -r EXAMPLE.LAB
Evil-WinRM shell v2.4

Info: Establishing connection to remote endpoint

Error: An error of type GSSAPI::GssApiError happened, message is gss_init_sec_context did not return GSS_S_COMPLETE: Unspecified GSS failure.  Minor code may provide more information
Matching credential not found (filename: /tmp/krb5cc_1000)


Error: Exiting with code 1
```

With the new ``-S`` switch, one can specify the lowercase SPN prefix and get it work:

```console
[pentester@kali ~]$  evil-winrm.rb -i dev.example.lab -r EXAMPLE.LAB -S http
Evil-WinRM shell v2.4

Info: Establishing connection to remote endpoint

*Evil-WinRM* PS C:\Users\Administrator\Documents>
```

Only a minor improvement, but could be useful :)
