### PR TITLE
Readline ANSI Escape Code [->dev]

### DIFF
--- a/evil-winrm.rb
+++ b/evil-winrm.rb
@@ -234,7 +234,7 @@ class EvilWinRM
     def colorize(text, color = "default")
         colors = {"default" => "38", "blue" => "34", "red" => "31", "yellow" => "1;33", "magenta" => "35"}
         color_code = colors[color]
-        return "\033[0;#{color_code}m#{text}\033[0m"
+        return "\001\033[0;#{color_code}m\002#{text}\001\033[0m\002"
     end
 
     # Messsage printing
@@ -456,8 +456,7 @@ class EvilWinRM
                     until command == "exit" do
                         pwd = shell.run("(get-location).path").output.strip
                         if $colors_enabled then
-                            print(self.colorize("*Evil-WinRM*", "red") + self.colorize(" PS ", "yellow") + pwd + "> ")
-                            command = Readline.readline('', true)
+                            command = Readline.readline(self.colorize("*Evil-WinRM*", "red") + self.colorize(" PS ", "yellow") + pwd + "> ", true)
                         else
                             command = Readline.readline("*Evil-WinRM* PS " + pwd + "> ", true)
                         end

--- a/evil-winrm.rb
+++ b/evil-winrm.rb
@@ -456,7 +456,8 @@ class EvilWinRM
                     until command == "exit" do
                         pwd = shell.run("(get-location).path").output.strip
                         if $colors_enabled then
-                            command = Readline.readline(self.colorize("*Evil-WinRM*", "red") + self.colorize(" PS ", "yellow") + pwd + "> ", true)
+                            print(self.colorize("*Evil-WinRM*", "red") + self.colorize(" PS ", "yellow") + pwd + "> ")
+                            command = Readline.readline('', true)
                         else
                             command = Readline.readline("*Evil-WinRM* PS " + pwd + "> ", true)
                         end


### PR DESCRIPTION
#### Describe the purpose of the pull request
ANSI was not being interpreted using the Readline module. The `*Evil-WinRM*` was not being parsed/printed correctly in the terminal when colors were enabled.

#### Versioning:
```
ruby -version                                                                                                                     
ruby 2.7.2p137 (2020-10-01 revision 5445e04352) [x86_64-linux-gnu]
gem list readline
*** LOCAL GEMS ***
readline (default: 0.0.2)
readline-ext (default: 0.1.0)
```
### Before:
![image](https://user-images.githubusercontent.com/61127067/109324391-9a6d2f00-7822-11eb-8fb7-ecc3ea559aca.png)
### After:
![image](https://user-images.githubusercontent.com/61127067/109324528-c688b000-7822-11eb-8465-aa52a4f4007c.png)

Please let me know if you would like to work with me to debug this issue further. However, this is the change I needed to make to make this work on my end. Not sure if there is anyone else out there with this issue.