### PR TITLE
Fixed a bug in `normalize_path`

### DIFF
--- a/evil-winrm.rb
+++ b/evil-winrm.rb
@@ -915,10 +915,7 @@ class EvilWinRM
     end
 
     def normalize_path(str)
-        p_str = str || ""
-        p_str = p_str.gsub('\\', '/')
-        p_str = Regexp.escape(p_str)
-        p_str
+        Regexp.escape(str.to_s.gsub('\\', '/'))
     end
 
     def get_dir_parts(n_path)

--- a/evil-winrm.rb
+++ b/evil-winrm.rb
@@ -916,8 +916,8 @@ class EvilWinRM
 
     def normalize_path(str)
         p_str = str || ""
-        p_str = str.gsub('\\', '/')
-        p_str = Regexp.escape(str)
+        p_str = p_str.gsub('\\', '/')
+        p_str = Regexp.escape(p_str)
         p_str
     end
 


### PR DESCRIPTION
Fixed what I'm pretty sure is a bug in `normalize_path`.The second line `p_str = str.gsub('\\','/')` was being overwrote by `p_str = Regexp.escape(str)`. Each normalization step should run on `p_str`.