### PR TITLE
Add default user agent

### DIFF
--- a/evil-winrm.rb
+++ b/evil-winrm.rb
@@ -53,8 +53,9 @@ $host = ""
 $port = "5985"
 $user = ""
 $password = ""
-$url = "wsman"
+$url = "wsman?PSVersion=5.1.19041.1237"
 $default_service = "HTTP"
+$USER_AGENT = 'Microsoft WinRM Client'
 $full_logging_path = ENV["HOME"]+"/evil-winrm-logs"
 
 # Redefine download method from winrm-fs
@@ -267,6 +268,7 @@ class EvilWinRM
                     transport: :ssl,
                     client_cert: $pub_key,
                     client_key: $priv_key,
+                    user_agent: $USER_AGENT,
                 )
             else
                 $conn = WinRM::Connection.new(
@@ -274,7 +276,8 @@ class EvilWinRM
                     user: $user,
                     password: $password,
                     :no_ssl_peer_verification => true,
-                    transport: :ssl
+                    transport: :ssl,
+                    user_agent: $USER_AGENT,
                 )
             end
 
@@ -285,15 +288,17 @@ class EvilWinRM
                 password: "",
                 transport: :kerberos,
                 realm: $realm,
-                service: $service
-            )
+                service: $service,
+                user_agent: $USER_AGENT,
+                )
         else
             $conn = WinRM::Connection.new(
                 endpoint: "http://#{$host}:#{$port}/#{$url}",
                 user: $user,
                 password: $password,
-                :no_ssl_peer_verification => true
-            )
+                :no_ssl_peer_verification => true,
+                user_agent: $USER_AGENT,
+                )
         end
     end
 


### PR DESCRIPTION
I recently discovered that the `winrm` library just uses a custom `User-Agent` header that would allow to distinct a legitimate use to the one that can be made with this tool.
Thus, I made a PR on `winrm` to introduce the possibility to set a custom `User-Agent` which was just merged (https://github.com/WinRb/WinRM/commit/033b439ed9349e0210f2cb6db7baec5f5c7fd948).

This PR uses this new option in order to set the `User-Agent` to the one the powershell would use. Moreover, at least on Windows 10, an argument `PSVersion` is also present, this PR add this in the default URL.

As the `winrm` has not published a new version on rubygem  yet and because I am not familiar with the ruby ecosystem, I am not sure if there is a way to support this PR until a new version is published and to modify the required dependency file. I'll try to remember to update this PR when a new release of `winrm` is released.