### PR TITLE
Fix for split and remote paths that contains spaces

### DIFF
--- a/evil-winrm.rb
+++ b/evil-winrm.rb
@@ -17,6 +17,7 @@ require 'io/console'
 require 'time'
 require 'fileutils'
 require 'logger'
+require 'shellwords'
 
 # Constants
 
@@ -678,6 +679,7 @@ class EvilWinRM
                 dest = ""
                 source = ""
                 paths = get_paths_from_command(command, pwd)
+
                 if paths.length == 2
                   dest = paths.pop
                   source = paths.pop
@@ -939,9 +941,8 @@ class EvilWinRM
   end
 
   def get_paths_from_command(command, pwd)
-    parts = command.split
+    parts = Shellwords.shellsplit(command)
     parts.delete_at(0)
-    parts.each { |p| p.gsub!('"', '') }
     return parts
   end
 


### PR DESCRIPTION
No fun when /data directory is upload to client system during test...

# Current (3.5 / what's on master)
![image](https://github.com/Hackplayers/evil-winrm/assets/6900588/b8c41736-a1e1-49e4-a794-3af997aa458c)

# This PR
![image](https://github.com/Hackplayers/evil-winrm/assets/6900588/2cee25b3-1a41-4564-a2fa-4abbe074e43d)

[Shellwords is part of the Ruby Standard Library](https://ruby-doc.org/stdlib-2.6.5/libdoc/shellwords/rdoc/Shellwords.html). It's a [improvement over using split](https://github.com/Hackplayers/evil-winrm/pull/55/files#diff-0ad98656153cbd4d84cdc7a285f11827ddc59b82d7921552b38d70f27d9d9319L942). This isn't adding more dependencies, just using what's available.