### PR TITLE
add utf-8 and remove readline

### DIFF
--- a/evil-winrm.rb
+++ b/evil-winrm.rb
@@ -57,6 +57,9 @@ $password = ''
 $url = 'wsman'
 $default_service = 'HTTP'
 $full_logging_path = "#{Dir.home}/evil-winrm-logs"
+# Encoding
+Encoding.default_external = Encoding::UTF_8
+Encoding.default_internal = Encoding::UTF_8
 
 # Redefine download method from winrm-fs
 module WinRM
@@ -592,9 +595,11 @@ class EvilWinRM
           until command == 'exit' do
             pwd = shell.run('(get-location).path').output.strip
             if $colors_enabled
-              command = Readline.readline( "#{colorize('*Evil-WinRM*', 'red')}#{colorize(' PS ', 'yellow')}#{pwd}> ", true)
+              print("#{colorize('*Evil-WinRM*', 'red')}#{colorize(' PS ', 'yellow')}#{pwd}> ")
+              command = STDIN.gets.chomp
             else
-              command = Readline.readline("*Evil-WinRM* PS #{pwd}> ", true)
+              print("*Evil-WinRM* PS #{pwd}> ", true)
+              command = STDIN.gets.chomp
             end
             $logger&.info("*Evil-WinRM* PS #{pwd} > #{command}")
 


### PR DESCRIPTION
<!--- Please, before sending a pull request read the Git Workflow Policy on Contributing section of the project -->
<!--- Pull requests to master are not allowed -->
<!--- Write in English only -->
<!--- If the pull request is not matching the policy, it will be closed -->

#### Describe the purpose of the pull request
The Ruby function _Readline.readline_ cannot work with utf-8 encoding (to be honest, I don't know why). Because of this, you won't be able to open files or enter folders whose names, for example, are written in Russian.

<!--- Insert answer here -->
I replaced the _Readline.readline_ with _print_+_STDIN.gets.chomp_
Before patch:
![image](https://github.com/Hackplayers/evil-winrm/assets/23736214/5f3031be-b8d6-4841-bb03-31308ea36d7a)
After patch:
![image](https://github.com/Hackplayers/evil-winrm/assets/23736214/e2e6f212-3b19-472d-a1c2-74a8afda3aa1)

