### PR TITLE
Fix undefined method exists when connection with certificate file.

### DIFF
--- a/evil-winrm.rb
+++ b/evil-winrm.rb
@@ -379,10 +379,10 @@ class EvilWinRM
     priv_key = priv_key.to_s
     if $ssl
       unless pub_key.empty? && priv_key.empty? then
-        unless [pub_key, priv_key].all? {|f| File.exists?(f) } then
-          print_message("Path to provided public certificate file \"#{pub_key}\" can't be found. Check filename or path", TYPE_ERROR, true, $logger) unless File.exists?(pub_key)
+        unless [pub_key, priv_key].all? {|f| File.exist?(f) } then
+          print_message("Path to provided public certificate file \"#{pub_key}\" can't be found. Check filename or path", TYPE_ERROR, true, $logger) unless File.exist?(pub_key)
 
-          print_message("Path to provided private certificate file \"#{priv_key}\" can't be found. Check filename or path", TYPE_ERROR, true, $logger) unless File.exists?(priv_key)
+          print_message("Path to provided private certificate file \"#{priv_key}\" can't be found. Check filename or path", TYPE_ERROR, true, $logger) unless File.exist?(priv_key)
 
           custom_exit(1)
         end


### PR DESCRIPTION
<!--- Please, before sending a pull request read the Git Workflow Policy on Contributing section of the project -->
<!--- Pull requests to master are not allowed -->
<!--- Write in English only -->
<!--- If the pull request is not matching the policy, it will be closed -->

#### Describe the purpose of the pull request
When connection using certificate public and private key, evil-winrm use `exists` function which is deprecated. This will raise the error `undefined method 'exists?' for File:Class (NoMethodError)`.

The newer version of Ruby use `exist` instead of `exists`. ([ruby doc](https://ruby-doc.org/core-2.2.0/File.html#exist-3F-method))
![image](https://github.com/Hackplayers/evil-winrm/assets/31753655/97dbce2d-8145-4ab3-9ba3-ba5c09471172)
