### PR TITLE
winrm (LoadError)

### DIFF
--- a/evil-winrm.gemspec
+++ b/evil-winrm.gemspec
@@ -25,11 +25,12 @@ Gem::Specification.new do |spec|
   spec.bindir = "bin"
   spec.executables = ["evil-winrm"]
 
-  spec.add_dependency 'fileutils', '~> 1.0'
-  spec.add_dependency 'logger',    '~> 1.4', '>= 1.4.3'
-  spec.add_dependency 'stringio',  '~> 3.0'
-  spec.add_dependency 'winrm',     '~> 2.3', '>= 2.3.2'
-  spec.add_dependency 'winrm-fs',  '~> 1.3', '>= 1.3.2'
+  spec.add_dependency 'fileutils',      '~> 1.0'
+  spec.add_dependency 'logger',         '~> 1.4', '>= 1.4.3'
+  spec.add_dependency 'stringio',       '~> 3.0'
+  spec.add_dependency 'winrm-elevated', '~> 1.2', '>= 1.2.3'
+  spec.add_dependency 'winrm',          '~> 2.3', '>= 2.3.2'
+  spec.add_dependency 'winrm-fs',       '~> 1.3', '>= 1.3.2'
 
   spec.add_development_dependency 'bundler', '~> 2.0'
 


### PR DESCRIPTION
#### Describe the purpose of the pull request

```
➜ ruby evil-winrm.rb 
<internal:/home/jvar/.rbenv/versions/3.0.0/lib/ruby/3.0.0/rubygems/core_ext/kernel_require.rb>:85:in `require': cannot load such file -- winrm (LoadError)
        from <internal:/home/jvar/.rbenv/versions/3.0.0/lib/ruby/3.0.0/rubygems/core_ext/kernel_require.rb>:85:in `require'
        from evil-winrm.rb:10:in `<main>'
```

Installing winrm-elevated fixed the issue..
```
➜ gem install winrm-elevated
Fetching winrm-elevated-1.2.3.gem
Fetching rubyzip-2.3.2.gem
Fetching winrm-fs-1.3.5.gem
RubyZip 3.0 is coming!
**********************
...[snip]...

➜ ruby evil-winrm.rb --version
v3.5
```
