### PR TITLE
fix(kerberos): need krb5-libs to auth w/ gssapi

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -84,6 +84,7 @@ RUN apk --no-cache add \
     readline \
     yaml \
     libffi \
+    krb5-libs \
     zlib \
     openssl
 


### PR DESCRIPTION
#### Describe the purpose of the pull request

Add krb5-libs to Dockerfile or you can't auth. w/ gssapi