### PR TITLE
fix(kerberos): need krb5-libs to auth w/ gssapi

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -93,6 +93,7 @@ FROM final
 RUN apk --no-cache add \
     readline \
     yaml \
+    krb5-libs \
     libffi
 
 # Make the ruby and Evil-WinRM paths available


### PR DESCRIPTION
#### Describe the purpose of the pull request
Add missing dep. `krb5-libs` to `Dockerfile` for GSSAPI auth. (kerberos...)