### PR TITLE
flush output of stdout

### DIFF
--- a/evil-winrm.rb
+++ b/evil-winrm.rb
@@ -94,6 +94,9 @@ $WORDS_RANDOM_CASE = [
 $colors_enabled = true
 $check_rpath_completion = true
 
+# Flush stdout after each write
+$stdout.sync = true
+
 # Path for ps1 scripts and exec files
 $scripts_path = ''
 $executables_path = ''


### PR DESCRIPTION
<!--- Please, before sending a pull request read the Git Workflow Policy on Contributing section of the project -->
<!--- Pull requests to master are not allowed -->
<!--- Write in English only -->
<!--- If the pull request is not matching the policy, it will be closed -->

#### Describe the purpose of the pull request
The output of stdout is no longer flushed. This is not a problem normally, but I run evil-winrm using a script. After I updated from 3.7 to 3.9 I get the following problem.
The problem is that on the current release of evil-winrm it prints nothing for the command, something like:
```
Command output:
Command. error output:
```

This is because the output is not flushed and it exits before the content is flushed to stdout. I am unsure, but I am guessing it's because evil-winrm now uses readline.

This PR makes stdout flushed after every call so the output will now look like:
```
Command output:
Evil-WinRM shell v3.9

Warning: Remote path completions is disabled due to ruby limitation: quoting_detection_proc() function is unimplemented on this machine

Data: For more information, check Evil-WinRM GitHub: https://github.com/Hackplayers/evil-winrm#Remote-path-completion

Info: Establishing connection to remote endpoint
hello

Info: Exiting with code 0

Command error output:
```

Please let me know if there are any problems. I am unfamiliar with ruby but this change fixes printing in my testing.

I won't post my exact code, but this sample go lang about covers it.
```GoLang
package main

import (
	"bytes"
	"fmt"
	"os/exec"
)

func main() {
	cmd := exec.Command("evil-winrm",
		"-u", "Administrator",
		"-p", "Password123!",
		"-i", "192.168.1.100",
		"-n",
	)

	stdin, err := cmd.StdinPipe()
	if err != nil {
		fmt.Println("Error obtaining stdin pipe:", err)
		return
	}
	defer stdin.Close()

	var stdout, stderr bytes.Buffer
	cmd.Stdout = &stdout
	cmd.Stderr = &stderr

	err = cmd.Start()
	if err != nil {
		fmt.Println("Error starting command:", err)
		return
	}

	_, err = stdin.Write([]byte("echo hello\nexit\n"))
	if err != nil {
		fmt.Println("Error writing to stdin:", err)
		return
	}

	err = cmd.Wait()
	if err != nil {
		fmt.Println("Error waiting for command:", err)
		return
	}

	fmt.Println("Command output:", stdout.String())
	fmt.Println("Command error output:", stderr.String())
}
```
