### PR TITLE
ruby 4.0 support, add readline gem dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ### 4.1
  - Enhanced compatibility with new bundler version
+ - Added Ruby 4.0 support
+ - Modernized Dockerfile
 
 ### 3.9
  - Quick fix of a broken dependency for Ruby gem (syslog)

--- a/Dockerfile
+++ b/Dockerfile
@@ -62,7 +62,7 @@ COPY . /opt/evil-winrm
 #RUN git clone -b ${BRANCH} ${EVILWINRM_URL}
 
 # Install Evil-WinRM ruby dependencies
-RUN gem update && gem install benchmark \
+RUN gem update && gem install --no-document benchmark \
     csv \
     fileutils \
     logger \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 # Evil-WinRM Dockerfile
 
 # Base image
-FROM alpine:3.20.3 AS final
-FROM alpine:3.20.3 AS build
+FROM alpine:3.23.3 AS final
+FROM alpine:3.23.3 AS build
 
 # Credits & Data
 LABEL \
@@ -37,14 +37,14 @@ RUN apk --no-cache add cmake \
     git
 
 # Make the ruby path available
-ENV PATH=$PATH:/opt/rubies/ruby-3.2.2/bin
+ENV PATH=$PATH:/opt/rubies/ruby-4.0.1/bin
 
-# Get ruby-install for building ruby 3.2.2
+# Get ruby-install for building ruby 4.0.1
 RUN cd /tmp/ && \
-    wget -O /tmp/ruby-install-0.8.1.tar.gz https://github.com/postmodern/ruby-install/archive/v0.8.1.tar.gz && \
-    tar -xzvf ruby-install-0.8.1.tar.gz && \
-    cd ruby-install-0.8.1/ && make install && \
-    ruby-install -c ruby 3.2.2 -- --with-readline-dir=/usr/include/readline --with-openssl-dir=/usr/include/openssl --disable-install-rdoc
+    wget -O /tmp/ruby-install-0.10.2.tar.gz https://github.com/postmodern/ruby-install/archive/v0.10.2.tar.gz && \
+    tar -xzvf ruby-install-0.10.2.tar.gz && \
+    cd ruby-install-0.10.2/ && make install && \
+    ruby-install -c ruby 4.0.1 -- --with-readline-dir=/usr/include/readline --with-openssl-dir=/usr/include/openssl --disable-install-rdoc
 
 # Set directory for the deploy of the application
 WORKDIR /opt
@@ -66,6 +66,7 @@ RUN gem install benchmark \
     csv \
     fileutils \
     logger \
+    readline \
     stringio \
     syslog \
     winrm \
@@ -100,7 +101,7 @@ RUN apk --no-cache add \
     libffi
 
 # Make the ruby and Evil-WinRM paths available
-ENV PATH=$PATH:/opt/rubies/ruby-3.2.2/bin:/opt/evil-winrm
+ENV PATH=$PATH:/opt/rubies/ruby-4.0.1/bin:/opt/evil-winrm
 
 # Copy built stuff from build image
 COPY --from=build /opt /opt

--- a/Dockerfile
+++ b/Dockerfile
@@ -67,6 +67,7 @@ RUN gem update && gem install --no-document benchmark \
     fileutils \
     logger \
     readline \
+    readline-ext \
     stringio \
     syslog \
     winrm \

--- a/Dockerfile
+++ b/Dockerfile
@@ -61,11 +61,8 @@ COPY . /opt/evil-winrm
 #ENV BRANCH="dev"
 #RUN git clone -b ${BRANCH} ${EVILWINRM_URL}
 
-# Install build dependencies to be able to build native extensions when installing ruby dependencies
-RUN apk add --no-cache --virtual build-dependencies build-base
-
 # Install Evil-WinRM ruby dependencies
-RUN gem install benchmark \
+RUN gem update && gem install benchmark \
     csv \
     fileutils \
     logger \
@@ -74,9 +71,6 @@ RUN gem install benchmark \
     syslog \
     winrm \
     winrm-fs
-
-# Remove build dependencies
-RUN apk del build-dependencies
 
 # Clean and remove useless files
 RUN rm -rf /opt/evil-winrm/resources > /dev/null 2>&1 && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,7 @@ RUN cd /tmp/ && \
     wget -O /tmp/ruby-install-0.10.2.tar.gz https://github.com/postmodern/ruby-install/archive/v0.10.2.tar.gz && \
     tar -xzvf ruby-install-0.10.2.tar.gz && \
     cd ruby-install-0.10.2/ && make install && \
-    ruby-install -c ruby 4.0.1 -- --with-readline-dir=/usr/include/readline --with-openssl-dir=/usr/include/openssl --disable-install-rdoc
+    ruby-install -c ruby 4.0.1 -- --with-readline-dir=/usr/include/readline --disable-install-rdoc
 
 # Set directory for the deploy of the application
 WORKDIR /opt

--- a/Dockerfile
+++ b/Dockerfile
@@ -61,6 +61,9 @@ COPY . /opt/evil-winrm
 #ENV BRANCH="dev"
 #RUN git clone -b ${BRANCH} ${EVILWINRM_URL}
 
+# Install build dependencies to be able to build native extensions when installing ruby dependencies
+RUN apk add --no-cache --virtual build-dependencies build-base
+
 # Install Evil-WinRM ruby dependencies
 RUN gem install benchmark \
     csv \
@@ -71,6 +74,9 @@ RUN gem install benchmark \
     syslog \
     winrm \
     winrm-fs
+
+# Remove build dependencies
+RUN apk del build-dependencies
 
 # Clean and remove useless files
 RUN rm -rf /opt/evil-winrm/resources > /dev/null 2>&1 && \

--- a/evil-winrm.gemspec
+++ b/evil-winrm.gemspec
@@ -25,15 +25,16 @@ Gem::Specification.new do |spec|
   spec.bindir = "bin"
   spec.executables = ["evil-winrm"]
 
-  spec.add_dependency 'benchmark', '>= 0.1.0'
-  spec.add_dependency 'csv',       '>= 2.4.8'
-  spec.add_dependency 'fileutils', '~> 1.0'
-  spec.add_dependency 'logger',    '~> 1.4', '>= 1.4.3'
-  spec.add_dependency 'readline',  '~> 0.0.4'
-  spec.add_dependency 'stringio',  '~> 3.0'
-  spec.add_dependency 'syslog',    '>= 0.3.0'
-  spec.add_dependency 'winrm',     '~> 2.3', '>= 2.3.7'
-  spec.add_dependency 'winrm-fs',  '~> 1.3', '>= 1.3.2'
+  spec.add_dependency 'benchmark',    '>= 0.1.0'
+  spec.add_dependency 'csv',          '>= 2.4.8'
+  spec.add_dependency 'fileutils',    '~> 1.0'
+  spec.add_dependency 'logger',       '~> 1.4', '>= 1.4.3'
+  spec.add_dependency 'readline',     '~> 0.0.4'
+  spec.add_dependency 'readline-ext', '~> 0.2.0'
+  spec.add_dependency 'stringio',     '~> 3.0'
+  spec.add_dependency 'syslog',       '>= 0.3.0'
+  spec.add_dependency 'winrm',        '~> 2.3', '>= 2.3.7'
+  spec.add_dependency 'winrm-fs',     '~> 1.3', '>= 1.3.2'
 
   spec.add_development_dependency 'bundler', '>= 2.0', '< 5.0'
 

--- a/evil-winrm.gemspec
+++ b/evil-winrm.gemspec
@@ -29,6 +29,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'csv',       '>= 2.4.8'
   spec.add_dependency 'fileutils', '~> 1.0'
   spec.add_dependency 'logger',    '~> 1.4', '>= 1.4.3'
+  spec.add_dependency 'readline',  '~> 0.0.4'
   spec.add_dependency 'stringio',  '~> 3.0'
   spec.add_dependency 'syslog',    '>= 0.3.0'
   spec.add_dependency 'winrm',     '~> 2.3', '>= 2.3.7'


### PR DESCRIPTION
Replaces #79 (only ruby 4.0 support without replacing readline by reline to avoid loosing remote completion support)

Steps to test:

```bash
cd $(mktemp -d)
git clone https://github.com/noraj/evil-winrm
cd evil-winrm
asdf set ruby 4.0.1
git checkout readline
bundle install
bundle exec ./evil-winrm.rb
docker build -f Dockerfile -t noraj/evil-winrm:4.1-readline .
docker run --rm -ti --name evil-winrm noraj/evil-winrm:4.1-readline
```

In dockerfile, I removed `--with-openssl-dir` ruby build option because manually specifying openssl location was making gem unable to find openssl even if the path value was correct, while relying on automatic path detection by default works perfectly fine.

PS: please squash merge