### PR TITLE
Fix path traversal in download_dir via server-controlled filenames

### DIFF
--- a/evil-winrm.rb
+++ b/evil-winrm.rb
@@ -155,7 +155,10 @@ module WinRM
         command = "Get-ChildItem #{remote_path} | Select-Object Name"
 
         @connection.shell(:powershell) { |e| e.run(command) }.stdout.strip.split(/\n/).drop(2).each do |file|
-          download(File.join(remote_file_path.to_s, file.strip), File.join(local_path, file.strip), chunk_size, false)
+          sanitized = File.basename(file.strip)
+          next if sanitized.empty? || sanitized == '.' || sanitized == '..'
+
+          download(File.join(remote_file_path.to_s, file.strip), File.join(local_path, sanitized), chunk_size, false)
         end
       end
 


### PR DESCRIPTION
## Summary

- `download_dir()` parses filenames from `Get-ChildItem` stdout and passes them directly to `File.join()` to build local file paths
- A rogue server can return filenames containing `../` sequences (e.g. `../../.ssh/authorized_keys`), causing files to be written outside the intended download directory
- Ruby's `File.join` does not sanitize traversal sequences: `File.join("/home/user/loot", "../../.ssh/authorized_keys")` resolves to `/home/user/.ssh/authorized_keys`

## Fix

Use `File.basename()` on server-supplied filenames for the local path construction only. The remote download path still uses the original filename so the correct file is fetched. Entries that resolve to empty, `.`, or `..` are skipped.

## Steps to reproduce

1. Set up a rogue Windows server that returns crafted filenames via `Get-ChildItem`
2. Connect with evil-winrm and run `download C:\loot\*`
3. Server returns filename `../../.ssh/authorized_keys`
4. File is written to `~/.ssh/authorized_keys` instead of the download directory